### PR TITLE
fix(ci): add GH_TOKEN for release creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: read
+            actions: read
             pull-requests: write
             security-events: write
         strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
         permissions:
             contents: read
             pull-requests: write
+            security-events: write
         strategy:
             matrix:
                 platform: [amd64, arm64]
@@ -85,4 +86,3 @@ jobs:
                 image_name: opentelemetry-mcp-server-${{ matrix.platform }}
                 scanners: secret,vuln
                 severity: CRITICAL,HIGH
-                github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,8 @@ jobs:
           echo "Version bump: ${{ steps.cz.outputs.version }}"
 
       - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh release create "${{ steps.cz.outputs.version }}" \
             --title "Release ${{ steps.cz.outputs.version }}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,6 @@ jobs:
           echo "Version bump: ${{ steps.cz.outputs.version }}"
 
       - name: Create GitHub Release
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh release create "${{ steps.cz.outputs.version }}" \
             --title "Release ${{ steps.cz.outputs.version }}" \


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `GH_TOKEN` to `release.yml` for GitHub release authentication.
> 
>   - **CI/CD**:
>     - Add `GH_TOKEN` environment variable to `Create GitHub Release` step in `release.yml` for authentication.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fopentelemetry-mcp-server&utm_source=github&utm_medium=referral)<sup> for cbe36d7da66e8366cf3d40130f545f0cbc41526c. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<img width="803" height="370" alt="Screenshot 2026-02-08 at 14 36 42" src="https://github.com/user-attachments/assets/e77847b8-f9bf-465b-87ec-92948e10bc19" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the release workflow with improved authentication to ensure more reliable and secure release creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->