### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Or use `uvx` (alternative):
 
 ---
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/traceloop-opentelemetry-mcp-server).
+
 ## Installation
 
 ### For End Users (Recommended)


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/traceloop-opentelemetry-mcp-server).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added hosted deployment information to documentation, including a link to deployment resources for running the server via a hosted service provider

<!-- end of auto-generated comment: release notes by coderabbit.ai -->